### PR TITLE
Fix deprecate for check_csrf_token for earlier versions of Pyramid (>=1.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 build
+.vscode
 *.egg-info
 .project
 .pydevproject

--- a/pyramid_yards/yards.py
+++ b/pyramid_yards/yards.py
@@ -5,8 +5,12 @@ import logging
 import colander
 import translationstring
 from functools import partial
-from pyramid.session import check_csrf_token as check_csrf
 from pyramid.httpexceptions import HTTPMethodNotAllowed
+
+try:
+    from pyramid.csrf import check_csrf_token as check_csrf
+except ImportError:
+    from pyramid.session import check_csrf_token as check_csrf
 
 log = logging.getLogger(__name__)
 _ = translationstring.TranslationStringFactory('pyramid-yards')


### PR DESCRIPTION
`check_csrf_token` are now on `pyramid.csrf` on Pyramid 1.9 (see: https://docs.pylonsproject.org/projects/pyramid/en/latest/changes.html#a1-2017-05-01)

cc @mardiros