### PR TITLE
Fix array deserialization in json dict key

### DIFF
--- a/pyramid_yards/yards.py
+++ b/pyramid_yards/yards.py
@@ -68,8 +68,11 @@ class RequestSchema(object):
                     data = getattr(request, attr.location)
                     if isinstance(attr, colander.SequenceSchema):
                         data = getattr(request, attr.location)
-                        vals = attr.deserialize(data.getall(key) or
-                                                attr.default)
+                        if attr.location == 'json':
+                            getall = data.get
+                        else:
+                            getall = data.getall
+                        vals = attr.deserialize(getall(key) or attr.default)
                         if vals != colander.drop:
                             vals = [val for val in vals
                                     if val != colander.drop]


### PR DESCRIPTION
json is a dict so it does not have a "getall" function